### PR TITLE
Handling mutli environment usage

### DIFF
--- a/lib/log-stash-stream.js
+++ b/lib/log-stash-stream.js
@@ -133,10 +133,9 @@ LogstashStream.prototype.write = function (entry) {
       trace += `-${lastTime - time} ms : ${record.msg} \n`
       try {
         trace += `${JSON.stringify(record, null, 3)} \n`
-      } catch (err){
+      } catch (err) {
         trace += `could not print all record fields \n`
       }
-
 
       if (record.trace) {
         trace += `Trace : ${JSON.stringify(record.trace)} \n`

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,5 +1,6 @@
 const config = require('config')
 const bunyan = require('bunyan')
+const path = require('path')
 
 const RotatingFileStream = require('bunyan-rotating-file-stream')
 const mkdirp = require('mkdirp')
@@ -12,7 +13,11 @@ class Logger {
       config.logger.file.enable === true
     ) {
       if (config.logger.file.dir) {
-        mkdirp.sync(config.logger.file.dir)
+        try{
+          mkdirp.sync(config.logger.file.dir)
+        }catch(err) {
+          console.warn('Unable to create targeted folder.', err)
+        }
       } else {
         console.log('Please define config.logger.file.dir in your config file')
       }
@@ -49,9 +54,7 @@ class Logger {
         level: config.logger.file.level,
         stream: new RotatingFileStream({
           // config.name comes from the including connector
-          path: `./${config.logger.file.dir}/${
-            config.name
-          }_all_%y-%m-%d.%N.log`,
+          path: path.join('.',config.logger.file.dir,`${config.name}_all_%y-%m-%d.%N.log`),
           period: '1d', // daily rotation
           totalFiles: 15, // keep up to 50 back copies
           rotateExisting: true, // Give ourselves a clean file when we start up, based on period

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -13,9 +13,9 @@ class Logger {
       config.logger.file.enable === true
     ) {
       if (config.logger.file.dir) {
-        try{
+        try {
           mkdirp.sync(config.logger.file.dir)
-        }catch(err) {
+        } catch (err) {
           console.warn('Unable to create targeted folder.', err)
         }
       } else {
@@ -54,7 +54,7 @@ class Logger {
         level: config.logger.file.level,
         stream: new RotatingFileStream({
           // config.name comes from the including connector
-          path: path.join('.',config.logger.file.dir,`${config.name}_all_%y-%m-%d.%N.log`),
+          path: path.join('.', config.logger.file.dir, `${config.name}_all_%y-%m-%d.%N.log`),
           period: '1d', // daily rotation
           totalFiles: 15, // keep up to 50 back copies
           rotateExisting: true, // Give ourselves a clean file when we start up, based on period

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "linter": "./node_modules/.bin/standard --fix --verbose",
-    "test": "npm run linter && NODE_ENV=localhost nyc ava"
+    "test": "npm run linter && cross-env NODE_ENV=localhost nyc ava"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Here is my little contribution to handle win/linux env usage.
Also added try catch in case of the folder to write log is not accessible.

I have also a concern about the config files. Some fields are checked with the conditions like:
```javascript
if (
      config.logger &&
      config.logger.file &&
      config.logger.file.enable === true
    ) 
```

But not all the fields, for example this one is not checked:
```javascript
   limit: config.logger.ringBuffer.size
```

Why don't we use a default file and to an Object.assign() with the passed configuration file?